### PR TITLE
Adding jax for xhr features 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# dolla #
+
+Inspired by [an article by Burke Holland](http://tech.pro/tutorial/1385/out-growing-jquery), a simple experiment about trying to rewrite jQuery.
+
+# jax #
+
+Inspired by the same article, an attempt at another jQuery.ajax.

--- a/jax.js
+++ b/jax.js
@@ -26,7 +26,12 @@
     * Don't shoot yourself in the foot by using multi-level objects.
     */
     function letsSerialize (args) {
+        // What if we got a null?
+        if (!args) {
+            return '';
+        }
         var ret = [];
+        
         for (key in args) {
             ret.push(encodeURIComponent(key) + '=' + encodeURIComponent(args[key]));
         }
@@ -39,7 +44,7 @@
     *
     * The magic happens!
     */
-    function callMeMaybe (url, cb, method, args) {
+    function callMeMaybe (url, cb, method, headers, args) {
         var xhr = letsMakeXhr();
         xhr.open(method, url, true);
         xhr.onreadystatechange = function () {
@@ -66,6 +71,10 @@
                 args = letsSerialize(args);
             }
         }
+        // we almost forgot them headers!
+        for (var i = 0; i < headers.length; ++i) {
+            xhr.setRequestHeader(headers[i][0], headers[i][1]);
+        }
         xhr.send(args);
         // useful when used as return value of an onclick function
         return false
@@ -73,17 +82,21 @@
 
 
     var jax = {
-        GET: function (url, cb) {
-            return callMeMaybe(url, cb, 'GET', null);
+        GET: function (url, headers, cb) {
+            if ('function' === typeof headers) cb = headers, headers = [];
+            return callMeMaybe(url, cb, 'GET', headers, null);
         },
-        DELETE: function (url, cb) {
-            return callMeMaybe(url, cb, 'DELETE', null);
+        DELETE: function (url, headers, cb) {
+            if ('function' === typeof headers) cb = headers, headers = [];
+            return callMeMaybe(url, cb, 'DELETE', headers, null);
         },
-        PUT: function (url, args, cb) {
-            return callMeMaybe(url, cb, 'PUT', args);
+        PUT: function (url, args, headers, cb) {
+            if ('function' === typeof headers) cb = headers, headers = [];
+            return callMeMaybe(url, cb, 'PUT', headers, args);
         },
-        POST: function (url, args, cb) {
-            return callMeMaybe(url, cb, 'POST', args);
+        POST: function (url, args, headers, cb) {
+            if ('function' === typeof headers) cb = headers, headers = [];
+            return callMeMaybe(url, cb, 'POST', headers, args);
         }
     };
 

--- a/jax.js
+++ b/jax.js
@@ -1,0 +1,94 @@
+// simple xhr implementation for dolla
+// nickname: jax
+;(function (undefined) {
+
+    /**
+    * function letsMakeXhr ()
+    *
+    * Should get you a XHR object from IE to Chrome.
+    */
+    function letsMakeXhr () {
+        try {
+            return new ActiveXObject('Msxml2.XMLHTTP');
+        } catch(e) {
+            try {
+                return new ActiveXObject('Microsoft.XMLHTTP');
+            } catch(e) {
+              return new XMLHttpRequest();
+            }
+        }
+    };
+
+
+    /**
+    * function letsSerialize (Object args)
+    *
+    * Don't shoot yourself in the foot by using multi-level objects.
+    */
+    function letsSerialize (args) {
+        var ret = [];
+        for (key in args) {
+            ret.push(encodeURIComponent(key) + '=' + encodeURIComponent(args[key]));
+        }
+        return ret.join('&');
+    }
+
+
+    /**
+    * function callMeMaybe (String url, Function cb, String method, Object/String args)
+    *
+    * The magic happens!
+    */
+    function callMeMaybe (url, cb, method, args) {
+        var xhr = letsMakeXhr();
+        xhr.open(method, url, true);
+        xhr.onreadystatechange = function () {
+            if (xhr.readyState === 4) {
+                var res = x.response.toString();
+                // we can kinda safely assume this is json with this
+                if (res[0] === '{' || res[0] === '[') {
+                    try {
+                        res = JSON.parse(res);
+                    } catch (e) {
+                        console.log('RES cannot be parsed');
+                    }
+                }
+                if (xhr.status !== 200) {
+                    return cb({status: xhr.status, error: res });
+                }
+                return cb(null, res);
+            }
+        }
+        // I love this trick :-)
+        if (~['POST', 'PUT'].indexOf(method)) {
+            xhr.setRequestHeader('Content-type','application/x-www-form-urlencoded');
+            if ('string' !== typeof args) {
+                args = letsSerialize(args);
+            }
+        }
+        xhr.send(args);
+        // useful when used as return value of an onclick function
+        return false
+    };
+
+
+    var jax = {
+        GET: function (url, cb) {
+            return callMeMaybe(url, cb, 'GET', null);
+        },
+        DELETE: function (url, cb) {
+            return callMeMaybe(url, cb, 'DELETE', null);
+        },
+        PUT: function (url, args, cb) {
+            return callMeMaybe(url, cb, 'PUT', args);
+        },
+        POST: function (url, args, cb) {
+            return callMeMaybe(url, cb, 'POST', args);
+        }
+    };
+
+
+    // dollajax sounds nice
+    window.$jax = jax;
+
+})();

--- a/jax.js
+++ b/jax.js
@@ -49,7 +49,7 @@
         xhr.open(method, url, true);
         xhr.onreadystatechange = function () {
             if (xhr.readyState === 4) {
-                var res = x.response.toString();
+                var res = xhr.response.toString();
                 // we can kinda safely assume this is json with this
                 if (res[0] === '{' || res[0] === '[') {
                     try {


### PR DESCRIPTION
A simple xhr library for dolla.

Usage: jax.METHOD(URL, [args,] callback)

Callback's prototype should be "function (err, data)".
